### PR TITLE
refactor: Message & User class

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,6 +1,6 @@
 import { env } from 'node:process';
 import { EventEmitter } from 'stream';
-import type { Channel, Guild } from 'structures';
+import type { Channel, Guild } from '../structures';
 import type { ClientOptions } from '../types/LIB';
 import { Gateway } from './ws/Gateway';
 

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,9 +1,8 @@
-import { Gateway } from '#client/ws/Gateway';
-import type { Channel } from '#structures/Channel';
-import type { Guild } from '#structures/Guild';
 import { env } from 'node:process';
 import { EventEmitter } from 'stream';
+import type { Channel, Guild } from 'structures';
 import type { ClientOptions } from '../types/LIB';
+import { Gateway } from './ws/Gateway';
 
 export class Client extends EventEmitter {
 	public gateway: Gateway;

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,6 +1,6 @@
 import { Gateway } from '#client/ws/Gateway';
-import type { Guild } from '#structures/Guild';
 import type { Channel } from '#structures/Channel';
+import type { Guild } from '#structures/Guild';
 import { env } from 'node:process';
 import { EventEmitter } from 'stream';
 import type { ClientOptions } from '../types/LIB';

--- a/src/client/ws/Gateway.ts
+++ b/src/client/ws/Gateway.ts
@@ -1,6 +1,5 @@
 import { Guild } from '#structures/Guild';
 import { Message } from '#structures/Message';
-import { User } from '#structures/User';
 import { log } from '#utils/logger';
 import type { APIMessage, APIUnavailableGuild, GatewayReadyDispatch } from 'discord-api-types/v10';
 import { WebSocket } from 'ws';
@@ -84,20 +83,7 @@ export class Gateway {
 						case 'MESSAGE_CREATE': {
 							const apiMessage = buffer.d as APIMessage;
 
-							const channel = this.client.channels.get(apiMessage.channel_id);
-
-							if (!apiMessage.guild_id) throw new Error('Direct messages are currently not supported');
-
-							const guild = this.client.guilds.get(apiMessage.guild_id);
-							const user = new User(
-								apiMessage.author.id,
-								apiMessage.author.username,
-								apiMessage.author.discriminator,
-								apiMessage.author.bot || false
-							);
-
-							if (!channel || !guild) throw new Error('Channel or guild not found!');
-							const message = new Message(apiMessage.id, apiMessage.content, guild, channel, user, this.client);
+							const message = new Message(apiMessage, this.client);
 							this.client.emit('message', message);
 						}
 					}

--- a/src/client/ws/Gateway.ts
+++ b/src/client/ws/Gateway.ts
@@ -1,7 +1,7 @@
 import { log } from 'console';
 import type { APIMessage, APIUnavailableGuild, GatewayReadyDispatch } from 'discord-api-types/v10';
-import { Guild, Message } from 'structures';
 import { WebSocket } from 'ws';
+import { Guild, Message } from '../../structures';
 import type { Client } from '../Client';
 
 export class Gateway {

--- a/src/client/ws/Gateway.ts
+++ b/src/client/ws/Gateway.ts
@@ -1,7 +1,6 @@
-import { Guild } from '#structures/Guild';
-import { Message } from '#structures/Message';
-import { log } from '#utils/logger';
+import { log } from 'console';
 import type { APIMessage, APIUnavailableGuild, GatewayReadyDispatch } from 'discord-api-types/v10';
+import { Guild, Message } from 'structures';
 import { WebSocket } from 'ws';
 import type { Client } from '../Client';
 

--- a/src/structures/Base.ts
+++ b/src/structures/Base.ts
@@ -1,4 +1,4 @@
-import type { Client } from '#client/Client';
+import type { Client } from 'client';
 
 export class Base {
 	public constructor(public client: Client) {

--- a/src/structures/Base.ts
+++ b/src/structures/Base.ts
@@ -1,4 +1,4 @@
-import type { Client } from 'client';
+import type { Client } from '../client';
 
 export class Base {
 	public constructor(public client: Client) {

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -1,6 +1,6 @@
-import type { Client } from '#client/Client';
-import { Base } from '#structures/Base';
+import type { Client } from 'client';
 import type { APIChannel } from 'discord-api-types/v10';
+import { Base } from './Base';
 import type { Guild } from './Guild';
 
 export class Channel extends Base {

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -4,11 +4,9 @@ import type { APIChannel } from 'discord-api-types/v10';
 import type { Guild } from './Guild';
 
 export class Channel extends Base {
-	public id: string;
+	public readonly id = this.raw.id;
 
-	public constructor(data: APIChannel, public guild: Guild, client: Client) {
+	public constructor(private raw: APIChannel, public guild: Guild, client: Client) {
 		super(client);
-
-		this.id = data.id;
 	}
 }

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -1,5 +1,5 @@
-import type { Client } from 'client';
 import type { APIChannel } from 'discord-api-types/v10';
+import type { Client } from '../client';
 import { Base } from './Base';
 import type { Guild } from './Guild';
 

--- a/src/structures/Guild.ts
+++ b/src/structures/Guild.ts
@@ -1,7 +1,7 @@
-import type { Client } from '#client/Client';
-import { Base } from '#structures/Base';
-import { Channel } from '#structures/Channel';
+import type { Client } from 'client';
 import type { APIGuild, Snowflake } from 'discord-api-types/v10';
+import { Base } from './Base';
+import { Channel } from './Channel';
 
 export class Guild extends Base {
 	public readonly id: Snowflake = this.data.id;

--- a/src/structures/Guild.ts
+++ b/src/structures/Guild.ts
@@ -1,18 +1,15 @@
 import type { Client } from '#client/Client';
 import { Base } from '#structures/Base';
 import { Channel } from '#structures/Channel';
-import type { APIGuild } from 'discord-api-types/v10';
+import type { APIGuild, Snowflake } from 'discord-api-types/v10';
 
 export class Guild extends Base {
-	public id: string;
-	public name: string;
+	public readonly id: Snowflake = this.data.id;
+	public name: string = this.data.name;
 	public channels: Map<string, Channel>;
 
 	public constructor(public data: APIGuild, client: Client) {
 		super(client);
-
-		this.id = data.id;
-		this.name = data.name;
 		this.channels = new Map(data.channels ? data.channels.map((chan: any) => [chan.id, new Channel(chan, this, client)]) : []);
 	}
 }

--- a/src/structures/Guild.ts
+++ b/src/structures/Guild.ts
@@ -1,5 +1,5 @@
-import type { Client } from 'client';
 import type { APIGuild, Snowflake } from 'discord-api-types/v10';
+import type { Client } from '../client';
 import { Base } from './Base';
 import { Channel } from './Channel';
 

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -9,9 +9,9 @@ import type { Guild } from './Guild';
 export class Message extends Base {
 	public id: Snowflake = this.data.id;
 	public content: string = this.data.content;
-	public guild: Guild | undefined = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
-	public channel: Channel | undefined = this.client.channels.get(this.data.channel_id);
-	public author: User | undefined = new User(
+	public guild?: Guild = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
+	public channel?: Channel = this.client.channels.get(this.data.channel_id);
+	public author?: User = new User(
 		this.data.author.id,
 		this.data.author.username,
 		this.data.author.discriminator,

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -1,7 +1,7 @@
 import type { Client } from '#client/Client';
 import { User } from '#structures/User';
 import { log } from '#utils/logger';
-import type { APIMessage, Snowflake } from 'discord-api-types/v10';
+import type { APIMessage, RESTPostAPIChannelMessageJSONBody, Snowflake } from 'discord-api-types/v10';
 import { fetch } from 'undici';
 import { Base } from './Base';
 import type { Channel } from './Channel';
@@ -17,7 +17,7 @@ export class Message extends Base {
 		super(client);
 	}
 
-	public async reply(payload: Omit<APIMessage, 'message_reference'>) {
+	public async reply(payload: Omit<RESTPostAPIChannelMessageJSONBody, 'message_reference'>) {
 		if (!this.channel) throw new Error('Cannot reply to a message that does not have a channel.');
 
 		const res = await fetch(`https://discord.com/api/v10/channels/${this.channel.id}/messages`, {

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -11,12 +11,7 @@ export class Message extends Base {
 	public content: string = this.data.content;
 	public guild?: Guild = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
 	public channel?: Channel = this.client.channels.get(this.data.channel_id);
-	public author?: User = new User(
-		this.data.author.id,
-		this.data.author.username,
-		this.data.author.discriminator,
-		this.data.author.bot || false
-	);
+	public author?: User = new User(this.data.author.id, this.data.author.username, this.data.author.discriminator, this.data.author.bot || false);
 
 	public constructor(private data: APIMessage, client: Client) {
 		super(client);

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -11,7 +11,8 @@ export class Message extends Base {
 	public content: string = this.data.content;
 	public guild?: Guild = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
 	public channel?: Channel = this.client.channels.get(this.data.channel_id);
-	public author: User = new User(this.data.author.id, this.data.author.username, this.data.author.discriminator, this.data.author.bot || false);
+	public author?: User = new User(this.data.author.id, this.data.author.username, this.data.author.discriminator, this.data.author.bot || false);
+	public webhookID?: Snowflake = this.data.webhook_id;
 
 	public constructor(private data: APIMessage, client: Client) {
 		super(client);

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -8,11 +8,14 @@ import type { Channel } from './Channel';
 import type { Guild } from './Guild';
 export class Message extends Base {
 	public id: Snowflake = this.data.id;
+
 	public content: string = this.data.content;
+
 	public guild?: Guild = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
 	public channel?: Channel = this.client.channels.get(this.data.channel_id);
-	public author?: User = new User(this.data.author.id, this.data.author.username, this.data.author.discriminator, this.data.author.bot || false);
-	public webhookID?: Snowflake = this.data.webhook_id;
+
+	public author?: User = new User(this.data.author);
+	public webhookId?: Snowflake = this.data.webhook_id;
 
 	public constructor(private data: APIMessage, client: Client) {
 		super(client);
@@ -38,7 +41,7 @@ export class Message extends Base {
 		if (res.ok) {
 			const apiMessage = (await res.json()) as APIMessage;
 
-			const user = new User(apiMessage.author.id, apiMessage.author.username, apiMessage.author.discriminator, apiMessage.author.bot || false);
+			const user = new User(apiMessage.author);
 
 			if (!user) throw new Error('User not found');
 

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -11,7 +11,7 @@ export class Message extends Base {
 	public content: string = this.data.content;
 	public guild?: Guild = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
 	public channel?: Channel = this.client.channels.get(this.data.channel_id);
-	public author?: User = new User(this.data.author.id, this.data.author.username, this.data.author.discriminator, this.data.author.bot || false);
+	public author: User = new User(this.data.author.id, this.data.author.username, this.data.author.discriminator, this.data.author.bot || false);
 
 	public constructor(private data: APIMessage, client: Client) {
 		super(client);

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -7,17 +7,17 @@ import { Base } from './Base';
 import type { Channel } from './Channel';
 import type { Guild } from './Guild';
 export class Message extends Base {
-	public id: Snowflake = this.data.id;
+	public readonly id: Snowflake = this.raw.id;
 
-	public content: string = this.data.content;
+	public content: string = this.raw.content;
 
-	public guild?: Guild = this.data.guild_id ? this.client.guilds.get(this.data.guild_id) : undefined;
-	public channel?: Channel = this.client.channels.get(this.data.channel_id);
+	public readonly guild?: Guild = this.raw.guild_id ? this.client.guilds.get(this.raw.guild_id) : undefined;
+	public readonly channel?: Channel = this.client.channels.get(this.raw.channel_id);
 
-	public author?: User = new User(this.data.author);
-	public webhookId?: Snowflake = this.data.webhook_id;
+	public readonly author?: User = new User(this.raw.author);
+	public readonly webhookId?: Snowflake = this.raw.webhook_id;
 
-	public constructor(private data: APIMessage, client: Client) {
+	public constructor(private raw: APIMessage, client: Client) {
 		super(client);
 	}
 

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -1,7 +1,7 @@
-import type { Client } from 'client';
 import { log } from 'console';
 import type { APIMessage, RESTPostAPIChannelMessageJSONBody, Snowflake } from 'discord-api-types/v10';
 import { fetch } from 'undici';
+import type { Client } from '../client';
 import { Base } from './Base';
 import type { Channel } from './Channel';
 import type { Guild } from './Guild';

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -1,11 +1,11 @@
-import type { Client } from '#client/Client';
-import { User } from '#structures/User';
-import { log } from '#utils/logger';
+import type { Client } from 'client';
+import { log } from 'console';
 import type { APIMessage, RESTPostAPIChannelMessageJSONBody, Snowflake } from 'discord-api-types/v10';
 import { fetch } from 'undici';
 import { Base } from './Base';
 import type { Channel } from './Channel';
 import type { Guild } from './Guild';
+import { User } from './User';
 export class Message extends Base {
 	public readonly id: Snowflake = this.raw.id;
 

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -1,7 +1,7 @@
 import type { Client } from '#client/Client';
 import { User } from '#structures/User';
 import { log } from '#utils/logger';
-import type { APIMessage, RESTPostAPIChannelMessageJSONBody, Snowflake } from 'discord-api-types/v10';
+import type { APIMessage, Snowflake } from 'discord-api-types/v10';
 import { fetch } from 'undici';
 import { Base } from './Base';
 import type { Channel } from './Channel';
@@ -17,7 +17,7 @@ export class Message extends Base {
 		super(client);
 	}
 
-	public async reply(payload: RESTPostAPIChannelMessageJSONBody) {
+	public async reply(payload: Omit<APIMessage, 'message_reference'>) {
 		if (!this.channel) throw new Error('Cannot reply to a message that does not have a channel.');
 
 		const res = await fetch(`https://discord.com/api/v10/channels/${this.channel.id}/messages`, {

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -1,3 +1,17 @@
+import type { APIUser } from 'discord-api-types/v10';
+
 export class User {
-	public constructor(public id: string, public username: string, public discriminator: string, public bot: boolean) {}
+	public id = this.raw.id;
+
+	public username = this.raw.username;
+	public discriminator = this.raw.discriminator;
+
+	public avatar = this.raw.avatar;
+	public banner = this.raw.banner;
+
+	public bot = this.raw.bot;
+	public verified = this.raw.verified;
+	public system = this.raw.system;
+
+	public constructor(private raw: APIUser) {}
 }

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,12 +1,12 @@
-import { Client } from '..';
-import type { Message } from '..';
 import 'dotenv/config';
+import type { Message } from '..';
+import { Client } from '..';
 
 const client = new Client();
 
 client.on('message', (message: Message) => {
-	console.log(message.content);
-	if (message.author.bot) return;
-
-	if (message.content === 'ai!ping') void message.reply('pong!');
+	if (message.content === 'ai!ping')
+		void message.reply({
+			content: 'pong!'
+		});
 });

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -5,8 +5,17 @@ import { Client } from '..';
 const client = new Client();
 
 client.on('message', (message: Message) => {
-	if (message.content === 'ai!ping')
+	if (message.content === 'test message')
 		void message.reply({
 			content: 'pong!'
+		});
+
+	if (message.content === 'test embed')
+		void message.reply({
+			embeds: [
+				{
+					description: 'hey an embed'
+				}
+			]
 		});
 });

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,10 +1,11 @@
 import 'dotenv/config';
-import type { Message } from '..';
-import { Client } from '..';
+import { Client, Message, User } from '..';
 
 const client = new Client();
 
 client.on('message', (message: Message) => {
+	// Only run if the user isn't a webhook
+	if (!(message.author instanceof User)) return;
 	if (message.content === 'test message')
 		void message.reply({
 			content: 'pong!'

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,13 +7,7 @@
 		"composite": true,
 		"preserveConstEnums": true,
 		"useDefineForClassFields": false,
-		"noImplicitReturns": true,
-		"paths": {
-			"#structures/*": ["structures/*"],
-			"#client/*": ["client/*"],
-			"#types/*": ["types/*"],
-			"#utils/*": ["utils/*"]
-		}
+		"noImplicitReturns": true
 	},
 	"include": ["."]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "./",
-		"baseUrl": "./",
 		"outDir": "../dist",
 		"composite": true,
 		"preserveConstEnums": true,


### PR DESCRIPTION
This pull request refactors the `Message` class to use the `RESTPostAPIChannelMessageJSONBody` type when replying and instead of taking id, content, guild, channel etc in the constructor it now takes a data argument of  `APIMessage` and the client.