### PR TITLE
fix: define readonly props

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -11,7 +11,7 @@ export class Client extends EventEmitter {
 	public readonly token = env.DISCORD_TOKEN as string;
 	public readonly guilds = new Map<string, Guild>();
 	public readonly channels = new Map<string, Channel>();
-	private readonly intents: number;
+	public intents: number;
 
 	public constructor(options: ClientOptions) {
 		super();
@@ -19,6 +19,6 @@ export class Client extends EventEmitter {
 	}
 
 	public login(token?: string) {
-		this.gateway._init((token ??= this.token), this.intents);
+		this.gateway._init((token ??= this.token));
 	}
 }

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,26 +1,24 @@
 import { env } from 'node:process';
 import { EventEmitter } from 'stream';
 import type { Channel, Guild } from '../structures';
-import { Gateway } from './ws/Gateway';
 import type { ClientOptions } from '../types/lib';
 import { REST } from './rest/REST';
+import { Gateway } from './ws/Gateway';
 
 export class Client extends EventEmitter {
-	public gateway: Gateway;
-	public rest: REST;
-	public token = env.DISCORD_TOKEN as string;
-	public intents: number;
-	public guilds = new Map<string, Guild>();
-	public channels = new Map<string, Channel>();
+	public readonly gateway = new Gateway(this);
+	public readonly rest = new REST(this);
+	public readonly token = env.DISCORD_TOKEN as string;
+	public readonly guilds = new Map<string, Guild>();
+	public readonly channels = new Map<string, Channel>();
+	private readonly intents: number;
 
 	public constructor(options: ClientOptions) {
 		super();
 		this.intents = options.intents || 0;
-		this.rest = new REST(this);
-		this.gateway = new Gateway(this);
 	}
 
 	public login(token?: string) {
-		this.gateway._init((token ??= this.token));
+		this.gateway._init((token ??= this.token), this.intents);
 	}
 }

--- a/src/client/ws/Gateway.ts
+++ b/src/client/ws/Gateway.ts
@@ -15,7 +15,7 @@ export class Gateway {
 
 	public constructor(private client: Client) {}
 
-	public _init(token: string, intents: number) {
+	public _init(token: string) {
 		this.socket.addEventListener('open', () => {
 			log({ state: 'WS', message: 'Connected to API' });
 		});
@@ -36,7 +36,7 @@ export class Gateway {
 					op: 2,
 					d: {
 						token,
-						intents,
+						intents: this.client.intents,
 						properties: {
 							$os: process ? process.platform : 'ailurus',
 							$browser: 'ailurus',

--- a/src/client/ws/Gateway.ts
+++ b/src/client/ws/Gateway.ts
@@ -1,7 +1,7 @@
-import { log } from '../../utils/logger';
 import type { APIMessage, APIUnavailableGuild, GatewayReadyDispatch } from 'discord-api-types/v10';
 import { WebSocket } from 'ws';
 import { Guild, Message } from '../../structures';
+import { log } from '../../utils/logger';
 import type { Client } from '../Client';
 
 export class Gateway {
@@ -15,7 +15,7 @@ export class Gateway {
 
 	public constructor(private client: Client) {}
 
-	public _init(token: string) {
+	public _init(token: string, intents: number) {
 		this.socket.addEventListener('open', () => {
 			log({ state: 'WS', message: 'Connected to API' });
 		});
@@ -36,7 +36,7 @@ export class Gateway {
 					op: 2,
 					d: {
 						token,
-						intents: this.client.intents,
+						intents,
 						properties: {
 							$os: process ? process.platform : 'ailurus',
 							$browser: 'ailurus',
@@ -68,7 +68,7 @@ export class Gateway {
 								const g = new Guild(buffer.d, this.client);
 								this.client.guilds.set(g.id, g);
 
-								this.client.channels = new Map([...g.channels.entries(), ...this.client.channels.entries()]);
+								g.channels.forEach((c) => this.client.channels.set(c.id, c));
 
 								this.readyGuilds = this.readyGuilds.filter((x) => x.id !== g.id);
 								if (this.readyGuilds.length === 0) this.client.emit('ready'), log({ state: 'WS', message: 'Guilds loaded' });

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -1,7 +1,7 @@
 import type { APIUser } from 'discord-api-types/v10';
 
 export class User {
-	public id = this.raw.id;
+	public readonly id = this.raw.id;
 
 	public username = this.raw.username;
 	public discriminator = this.raw.discriminator;
@@ -9,9 +9,9 @@ export class User {
 	public avatar = this.raw.avatar;
 	public banner = this.raw.banner;
 
-	public bot = this.raw.bot;
+	public readonly bot = this.raw.bot;
 	public verified = this.raw.verified;
-	public system = this.raw.system;
+	public readonly system = this.raw.system;
 
 	public constructor(private raw: APIUser) {}
 }


### PR DESCRIPTION
## Properties that never get redefined are now read-only.

I decided to make some properties that can change such as `username` on the `User` class aren't as I wasn't sure in the future if we would implement some caching system where it would update the class when said user changes their username.