### PR TITLE
refactor: Apply naming conventions

### DIFF
--- a/src/structures/Guild.ts
+++ b/src/structures/Guild.ts
@@ -5,14 +5,14 @@ import { Channel } from './Channel';
 import { Role } from './Role';
 
 export class Guild extends Base {
-	public readonly id: Snowflake = this.data.id;
-	public name: string = this.data.name;
+	public readonly id: Snowflake = this.raw.id;
+	public name: string = this.raw.name;
 	public channels: Map<string, Channel>;
 	public roles: Map<string, Role>;
 
-	public constructor(public data: APIGuild, client: Client) {
+	public constructor(private raw: APIGuild, client: Client) {
 		super(client);
-		this.channels = new Map(data.channels ? data.channels.map((chan: any) => [chan.id, new Channel(chan, this, client)]) : []);
-		this.roles = new Map(data.roles ? data.roles.map((role: APIRole) => [role.id, new Role(role, this.client)]) : []);
+		this.channels = new Map(raw.channels ? raw.channels.map((chan: any) => [chan.id, new Channel(chan, this, client)]) : []);
+		this.roles = new Map(raw.roles ? raw.roles.map((role: APIRole) => [role.id, new Role(role, this.client)]) : []);
 	}
 }


### PR DESCRIPTION
Guild Class had the `data` property public, and had a different naming conventions compared to other structs